### PR TITLE
fix arm compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ thiserror = "1.0"
 [features]
 vp9 = []
 backtrace = []
+ffi-generate = ["env-libvpx-sys/generate"]
 
 [package.metadata.docs.rs]
 features = [ "vp9" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,7 @@ impl Drop for Encoder {
         unsafe {
             let result = vpx_codec_destroy(&mut self.ctx);
             if result != vpx_sys::VPX_CODEC_OK {
-                panic!("failed to destroy vpx codec");
+                eprintln!("failed to destroy vpx codec: {result:?}");
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,8 +106,7 @@ macro_rules! call_vpx {
 macro_rules! call_vpx_ptr {
     ($x:expr) => {{
         let result = unsafe { $x }; // original expression
-        let result_int = unsafe { std::mem::transmute::<_, i64>(result) };
-        if result_int == 0 {
+        if result.is_null() {
             return Err(Error::from("Bad pointer.".to_string()));
         }
         result


### PR DESCRIPTION
There is a bug on arm because pointer width is not 64 bits, hence the transmute does not compile.
I removed unnecessary transmute in the null pointer check.